### PR TITLE
Ensures that ISO download dir exists

### DIFF
--- a/tasks/isos.yml
+++ b/tasks/isos.yml
@@ -1,9 +1,11 @@
 ---
 - name: Ensure requested download dir exists
   file:
-    path: "{{ item.path }}"
+    path: "{{ item.path|dirname }}"
     state: directory
     mode: 0775
+  with_items:
+    - "{{ mount_isos }}"
 
 - name: Pull ISOs
   get_url:

--- a/tasks/isos.yml
+++ b/tasks/isos.yml
@@ -1,4 +1,10 @@
 ---
+- name: Ensure requested download dir exists
+  file:
+    path: "{{ item.path }}"
+    state: directory
+    mode: 0775
+
 - name: Pull ISOs
   get_url:
      url: "{{ item.origin }}"


### PR DESCRIPTION
If the user creates a custom path like `/mnt/iso` as a folder to store multiple files in this now handles that for them.